### PR TITLE
Implement Pagination for API Endpoint

### DIFF
--- a/src/controllers/crawledDataController.ts
+++ b/src/controllers/crawledDataController.ts
@@ -3,11 +3,12 @@
  *
  * @module crawledDataController.ts
  * @author Hristo Georgiev <hristogeorgiew84@gmail.com>
+ * @author Daniel Batanov <batanoff.s@protonmail.com>
  */
 
 // Import dependencies
 import { Router, Request, Response } from "express";
-import { getAllCrawledData } from "../services/crawledDataService";
+import { getAllCrawledData, getCrawledDataPagination } from "../services/crawledDataService";
 import { ErrorType } from "../types/errorType";
 
 // Create a new router
@@ -28,6 +29,65 @@ router.get("/api/crawled-data", async (req: Request, res: Response) => {
     } catch (error) {
         // Log the error and respond with an error message
         res.status(500).send((error as ErrorType).message)
+    }
+});
+
+/**
+ * @endpoint GET /api/crawled-data
+ * @description Fetch CrawledData records based on page and limit query params.
+ */
+router.get("/api/crawled-data/filter", async (req: Request, res: Response) => {
+    // Define default variables
+    let currentPage = 1;
+    let currentLimit = 10;
+
+    // Get query params
+    const {page, limit} = req.query;
+
+    try {
+        // Validate if query params are negative or zero
+        if (isNaN(Number(page)) && Number(page) < 1) throw new Error("Page must be a positive number, greater or equal to 1!");
+        if (isNaN(Number(limit)) && Number(limit) < 1) throw new Error("Limit must be a positive number, greater or equal to 1!");
+
+        // Update default params with provided query params
+        currentPage = Number(page ?? currentPage);
+        currentLimit = Number(limit ?? currentLimit);
+
+        // Call the service for pagination
+        const result = await getCrawledDataPagination(currentPage, currentLimit);
+
+        // Check total value and set default
+        const totalPages = result.total ?? 1;
+
+        // Check if current page is greater then total pages
+        if (currentPage > totalPages) throw new Error("Current page is greater than total pages!");
+
+        // Define prev and next constants, 
+        // TODO update "http://localhost:3000/" with env variable
+        const next = currentPage < totalPages ? `http://localhost:3000/api/crawled-data/paginated?page=${currentPage + 1}&limit=${currentLimit}` : null;
+        const prev = currentPage > 1 && currentPage <= totalPages ? `http://localhost:3000/api/crawled-data/paginated?page=${currentPage - 1}&limit=${currentLimit}` : null;
+
+        // Create pagination metadata
+        const pagination = {
+            totalPages,
+            currentPage,
+            next,
+            prev
+        };
+
+        // Send response
+        res.status(200).send({
+            status: 'success',
+            pagination,
+            data: result.data
+        });
+    }
+    catch (error) {
+        // Log the error and respond with an error message
+        res.status(400).send({
+                status: 'error',
+                error: (error as ErrorType).message
+        })
     }
 });
 

--- a/src/controllers/crawledDataController.ts
+++ b/src/controllers/crawledDataController.ts
@@ -59,9 +59,6 @@ router.get("/api/crawled-data/filter", async (req: Request, res: Response) => {
         // Check total value and set default
         const totalPages = result.total ?? 1;
 
-        // Check if current page is greater then total pages
-        if (currentPage > totalPages) throw new Error("Current page is greater than total pages!");
-
         // Define prev and next constants, 
         // TODO update "http://localhost:3000/" with env variable
         const next = currentPage < totalPages ? `http://localhost:3000/api/crawled-data/paginated?page=${currentPage + 1}&limit=${currentLimit}` : null;

--- a/src/controllers/crawledDataController.ts
+++ b/src/controllers/crawledDataController.ts
@@ -10,6 +10,7 @@
 import { Router, Request, Response } from "express";
 import { getAllCrawledData, getCrawledDataPagination } from "../services/crawledDataService";
 import { ErrorType } from "../types/errorType";
+import logger from "../utils/logger";
 
 // Create a new router
 const router = Router();
@@ -20,13 +21,22 @@ const router = Router();
  */
 router.get("/api/crawled-data", async (req: Request, res: Response) => {
 
+    // Try to fetch data
     try {
         // Call the service
         const data = await getAllCrawledData(req, res)
 
+        logger.info("Fetched all crawled data successfully.");
+
         // Send response
         res.status(200).send(data)
-    } catch (error) {
+    } 
+    
+    // Catch errors
+    catch (error) {
+
+        logger.error(error);
+
         // Log the error and respond with an error message
         res.status(500).send((error as ErrorType).message)
     }
@@ -37,6 +47,7 @@ router.get("/api/crawled-data", async (req: Request, res: Response) => {
  * @description Fetch CrawledData records based on page and limit query params.
  */
 router.get("/api/crawled-data/filter", async (req: Request, res: Response) => {
+    
     // Define default variables
     let currentPage = 1;
     let currentLimit = 10;
@@ -44,10 +55,16 @@ router.get("/api/crawled-data/filter", async (req: Request, res: Response) => {
     // Get query params
     const {page, limit} = req.query;
 
+    // Try to fetch data
     try {
-        // Validate if query params are negative or zero
-        if (isNaN(Number(page)) && Number(page) < 1) throw new Error("Page must be a positive number, greater or equal to 1!");
-        if (isNaN(Number(limit)) && Number(limit) < 1) throw new Error("Limit must be a positive number, greater or equal to 1!");
+
+        // Validate page query param
+        if (isNaN(Number(page)) && Number(page) < 1) 
+            throw new Error("Page must be a positive number, greater or equal to 1!");
+
+        // Validate limit query param
+        if (isNaN(Number(limit)) && Number(limit) < 1) 
+            throw new Error("Limit must be a positive number, greater or equal to 1!");
 
         // Update default params with provided query params
         currentPage = Number(page ?? currentPage);
@@ -72,6 +89,9 @@ router.get("/api/crawled-data/filter", async (req: Request, res: Response) => {
             prev
         };
 
+        // Log success
+        logger.info(`Fetched ${totalPages} pages from CrawledData table`);
+
         // Send response
         res.status(200).send({
             status: 'success',
@@ -79,7 +99,12 @@ router.get("/api/crawled-data/filter", async (req: Request, res: Response) => {
             data: result.data
         });
     }
+
+    // Catch errors
     catch (error) {
+
+        logger.error(error);
+
         // Log the error and respond with an error message
         res.status(400).send({
                 status: 'error',
@@ -90,4 +115,3 @@ router.get("/api/crawled-data/filter", async (req: Request, res: Response) => {
 
 // Export the router
 export default router;
-

--- a/src/services/crawledDataService.ts
+++ b/src/services/crawledDataService.ts
@@ -13,7 +13,10 @@ import { PaginationResult } from "../types/pagination";  // Import types
 
 // Get all CrawledData records with related SourceUrls and Sources
 export const getAllCrawledData = async (req: Request, res: Response) => {
+
+    // Try to fetch data
     try {
+        
         // Get all crawled data from the database
         const crawledData = await prisma.crawledData.findMany();
 
@@ -22,7 +25,11 @@ export const getAllCrawledData = async (req: Request, res: Response) => {
 
         // Return all crawled data
         return crawledData;
-    } catch (error) {
+    } 
+    
+    // Catch errors
+    catch (error) {
+
         // Log the error
         logger.error("Error fetching crawled data:", error);
 
@@ -33,6 +40,8 @@ export const getAllCrawledData = async (req: Request, res: Response) => {
 
 // Get limited CrawledData records based on pagination provided in query params
 export const getCrawledDataPagination = async (page: number, limit: number): Promise<PaginationResult> => {
+
+    // Try to fetch data
     try {
         // Get total records of crawled data
         const totalEntries = await prisma.crawledData.count();
@@ -51,9 +60,11 @@ export const getCrawledDataPagination = async (page: number, limit: number): Pro
 
         // Return all crawled data
         return {data, total};
-
+    } 
+    
     // Catch errors 
-    } catch (error) {
+    catch (error) {
+
         // Log the error
         logger.error("Error fetching crawled data:", error);
         

--- a/src/services/crawledDataService.ts
+++ b/src/services/crawledDataService.ts
@@ -2,12 +2,14 @@
  * CrawledData Service
  *
  * @module crawledDataService.ts
- * @authowr Hristo Georgiev <hristogeorgiew84@gmail.com>
+ * @author Hristo Georgiev <hristogeorgiew84@gmail.com>
+ * @author Daniel Batanov <batanoff.s@protonmail.com>
  */
 
 import prisma from "../db/prisma/prisma";
 import { Request, Response } from "express";
 import logger from "../utils/logger"; // Import winston logger
+import { PaginationResult } from "../types/pagination";  // Import types
 
 // Get all CrawledData records with related SourceUrls and Sources
 export const getAllCrawledData = async (req: Request, res: Response) => {
@@ -26,5 +28,36 @@ export const getAllCrawledData = async (req: Request, res: Response) => {
 
         // Send a server error message
         res.status(500).json({ message: "Failed to fetch crawled data." });
+    }
+};
+
+// Get limited CrawledData records based on pagination provided in query params
+export const getCrawledDataPagination = async (page: number, limit: number): Promise<PaginationResult> => {
+    try {
+        // Get total records of crawled data
+        const totalEntries = await prisma.crawledData.count();
+
+        // Get data filtered by limit and page
+        const data = await prisma.crawledData.findMany({
+            take: limit,
+            skip: (page - 1) * limit,
+        });
+
+        // Calculate total pages
+        const total = Math.ceil(totalEntries / limit);
+
+        // Log success
+        logger.info("Fetched filtered crawled data successfully.");
+
+        // Return all crawled data
+        return {data, total};
+
+    // Catch errors 
+    } catch (error) {
+        // Log the error
+        logger.error("Error fetching crawled data:", error);
+        
+        // Return error object
+        return {error: (error as Error).message};
     }
 };

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,7 @@
+import { CrawledData } from "@prisma/client"
+
+export type PaginationResult = {
+    total?: number,
+    data?: CrawledData[],
+    error?: string
+}


### PR DESCRIPTION
Implemented service and controller for crawled data pagination. The route that it works on is `../api/crawled-data/filter` and then params as `?page=1&limit=10`. As the page and limit has default values if not passed as query params.

How it works:
- Pass `limit` and `page` as query props to request the data, or if nothing is passed it will take default props as page =1 and limit = 10;
- All validations should work as expected, if current page > total page or query params are valid or not;
- After success the server returns an object with params:
  ```
  {
      "status": "success", // the response status
      "pagination": {  //details about pagination
          "totalPages": 1,
          "currentPage": 1,
          "next": null,
          "prev": null
      },
      "data": [{},{}] //response data 
  }
  ```

- If response has error it returns an object:
  ```
  {
      "status": "error",
      "error": "Current page is greater than total pages!"
  }
  ```
- validation is implemented for next and prev urls based on pages 

Note:
It is possible to merge the logic of `getAllCrawledData` and  `getCrawledDataPagination`, this will remove the issue for having two different routes. But then the route will look like `api/crawled-data?pagination=true&page=1&limit=10`, since we need a way to validate if pagination is requested or not. Other possible solution is to create it as middleware.